### PR TITLE
refactor: standardize RESTful API routes

### DIFF
--- a/src/routes/AttributeRouter.ts
+++ b/src/routes/AttributeRouter.ts
@@ -9,10 +9,10 @@ import {
 
 const router = Router();
 
-router.post('/attributes', createAttribute);
-router.get('/attributes', getAllAttributes);
-router.get('/attributes/:id', getAttributeById);
-router.put('/attributes/:id', updateAttribute);
-router.delete('/attributes/:id', deleteAttribute);
+router.post('/', createAttribute);
+router.get('/', getAllAttributes);
+router.get('/:id', getAttributeById);
+router.put('/:id', updateAttribute);
+router.delete('/:id', deleteAttribute);
 
 export default router;

--- a/src/routes/AttributeValueRoute.ts
+++ b/src/routes/AttributeValueRoute.ts
@@ -9,10 +9,10 @@ import {
 
 const router = Router();
 
-router.post('/attribute-values', createAttributeValue);
-router.get('/attribute-values', getAllAttributesValues);
-router.get('/attribute-values/:id', getAttributeValueById);
-router.put('/attribute-values/:id', updateAttributeValue);
-router.delete('/attribute-values/:id', deleteAttributeValue);
+router.post('/', createAttributeValue);
+router.get('/', getAllAttributesValues);
+router.get('/:id', getAttributeValueById);
+router.put('/:id', updateAttributeValue);
+router.delete('/:id', deleteAttributeValue);
 
 export default router;

--- a/src/routes/UserRoutes.ts
+++ b/src/routes/UserRoutes.ts
@@ -15,12 +15,12 @@ const router = Router();
 // Route to get all users
 router.get('/', sessionMiddleware, getAllUsers);
 // Route to create a new user with validation
-router.post('/create', validationMiddleware(CreateUserDto), createUser);
+router.post('/', validationMiddleware(CreateUserDto), createUser);
 // Route to get a specific user by ID
-router.get('/show/:id', sessionMiddleware, getUser);
+router.get('/:id', sessionMiddleware, getUser);
 // Route to update a user by ID with validation
-router.put('/update/:id', sessionMiddleware, validationMiddleware(UpdateUserDto), updateUser);
+router.put('/:id', sessionMiddleware, validationMiddleware(UpdateUserDto), updateUser);
 // Route to delete a user by ID
-router.delete('/delete/:id', sessionMiddleware, deleteUser);
+router.delete('/:id', sessionMiddleware, deleteUser);
 
 export default router;


### PR DESCRIPTION
- Remove duplicate path prefixes from attribute and attribute-value routes
- Standardize user routes to follow RESTful conventions
- Replace /create, /show, /update, /delete with standard REST methods
- Clean up route structure for better API consistency

# 🚀 StarShop Pull Request

Mark with an `x` all the checkboxes that apply (like `[x]`)

- [x] Closes #49 
- [ ] Added tests (if necessary)
- [ ] Run tests
- [ ] Run formatting
- [ ] Evidence attached
- [ ] Commented the code

---

### 📌 Type of Change

- [ ] Documentation (updates to README, docs, or comments)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

---

## 📝 Changes description

1. **Attribute Routes**
   - Removed duplicate `/attributes` prefix
   - Now using clean paths: `GET /attributes`, `POST /attributes`, etc.

2. **Attribute Value Routes**
   - Removed duplicate `/attribute-values` prefix
   - Now using clean paths: `GET /attribute-values`, `POST /attribute-values`, etc.

3. **User Routes**
   - Standardized to RESTful conventions:
     - `GET /users/show/:id` → `GET /users/:id`
     - `PUT /users/update/:id` → `PUT /users/:id`
     - `DELETE /users/delete/:id` → `DELETE /users/:id`
     - `POST /users/create` → `POST /users`



---

## 📸 Evidence (A photo is required as evidence)



---

## ⏰ Time spent breakdown



---

## 🌌 Comments



---

Thank you for contributing to StarShop, we are glad that you have chosen us as your project of choice and we hope that you continue to contribute to this great project, so that together we can make our mark at the top!
