### PR TITLE
Standardize API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,9 @@ To access the docs:
 
 1. Edit the `openapi.yaml` file
 2. Add/update endpoint documentation following OpenAPI spec
-3. Restart the server to see changes
-4. Validate schema: `npm run docs:validate`
+3. Consulta `docs/api-guidelines.md` para mantener la nomenclatura consistente
+4. Restart the server to see changes
+5. Validate schema: `npm run docs:validate`
 
 ### Generating Static Docs
 

--- a/docs/api-guidelines.md
+++ b/docs/api-guidelines.md
@@ -1,0 +1,18 @@
+# API Endpoint Guidelines
+
+Este documento resume el estándar adoptado para diseñar y documentar los endpoints de StarShop.
+
+## Convenciones generales
+
+- **Formato REST:** Se utilizan rutas basadas en recursos. Cada recurso se maneja con los métodos HTTP correspondientes:
+  - `GET /recurso` para listar
+  - `POST /recurso` para crear
+  - `GET /recurso/{id}` para obtener un elemento
+  - `PUT` o `PATCH /recurso/{id}` para actualizar
+  - `DELETE /recurso/{id}` para eliminar
+- **Prefijo de versión:** Todos los endpoints se sirven bajo `/api/v1`.
+- **Nomenclatura de paths:** Se emplea *kebab-case* y nombres en plural para los recursos. Evitar prefijos como `show`, `update` o `delete` en la ruta.
+- **Manejo de errores:** Los controladores deben usar las clases definidas en `src/utils/errors` para enviar respuestas coherentes.
+- **Documentación:** Actualizar `openapi.yaml` al crear o modificar endpoints siguiendo esta estructura.
+
+Seguir estas reglas permite una API consistente y fácil de consumir.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -65,7 +65,7 @@ paths:
         400:
           $ref: "#/components/responses/ValidationError"
 
-  /users/show/{id}:
+  /users/{id}:
     get:
       tags: [Users]
       summary: Get a specific user by ID
@@ -88,7 +88,6 @@ paths:
         404:
           $ref: "#/components/responses/NotFound"
 
-  /users/update/{id}:
     put:
       tags: [Users]
       summary: Update a user by ID
@@ -118,7 +117,6 @@ paths:
         404:
           $ref: "#/components/responses/NotFound"
 
-  /users/delete/{id}:
     delete:
       tags: [Users]
       summary: Delete a user by ID
@@ -137,7 +135,7 @@ paths:
         404:
           $ref: "#/components/responses/NotFound"
 
-  /attributes/attributes:
+  /attributes:
     get:
       tags: [Attributes]
       summary: Get all attributes with pagination
@@ -166,7 +164,7 @@ paths:
                 items:
                   $ref: "#/components/schemas/Attribute"
 
-  /attribute-values/attribute-values:
+  /attribute-values:
     get:
       tags: [AttributeValues]
       summary: Get all attribute values with pagination


### PR DESCRIPTION
## Summary
- document API endpoint conventions in `docs/api-guidelines.md`
- link the new guidelines from the README
- normalize REST paths in `openapi.yaml`

## Testing
- `npm run test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c81920e80833095b6568b26119f5b