### PR TITLE
start disputes

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-checkout' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+git lfs post-checkout "$@"

--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-commit' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+git lfs post-commit "$@"

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-merge' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+git lfs post-merge "$@"

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'pre-push' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+git lfs pre-push "$@"

--- a/src/modules/disputes/controllers/dispute.controller.ts
+++ b/src/modules/disputes/controllers/dispute.controller.ts
@@ -1,0 +1,20 @@
+import { Controller, Post, Body, Req, UseGuards } from '@nestjs/common';
+import { DisputeService } from '../services/dispute.service';
+import { AuthenticatedRequest } from '../../shared/types/auth-request.type';
+import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+
+@Controller('disputes')
+export class DisputeController {
+  constructor(private readonly disputeService: DisputeService) {}
+
+  @UseGuards(JwtAuthGuard)
+  @Post('start')
+  async startDispute(
+    @Body('orderItemId') orderItemId: string,
+    @Body('reason') reason: string,
+    @Req() req: AuthenticatedRequest
+  ) {
+    const buyer = req.user;
+    return this.disputeService.startDispute(orderItemId, buyer, reason);
+  }
+}

--- a/src/modules/disputes/entities/1695840000000-CreateDisputeTable.ts
+++ b/src/modules/disputes/entities/1695840000000-CreateDisputeTable.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class CreateDisputeTable1695840000000 implements MigrationInterface {
+    name = 'CreateDisputeTable1695840000000'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE "disputes" (
+            "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+            "order_itemId" uuid NOT NULL,
+            "buyerId" uuid NOT NULL,
+            "status" varchar NOT NULL DEFAULT 'OPEN',
+            "reason" text,
+            "created_at" TIMESTAMP NOT NULL DEFAULT now(),
+            CONSTRAINT "PK_dispute_id" PRIMARY KEY ("id"),
+            CONSTRAINT "UQ_dispute_order_item" UNIQUE ("order_itemId"),
+            CONSTRAINT "FK_dispute_order_item" FOREIGN KEY ("order_itemId") REFERENCES "order_items"("id") ON DELETE CASCADE,
+            CONSTRAINT "FK_dispute_buyer" FOREIGN KEY ("buyerId") REFERENCES "users"("id") ON DELETE CASCADE
+        )`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP TABLE "disputes"`);
+    }
+}

--- a/src/modules/disputes/entities/dispute.entity.ts
+++ b/src/modules/disputes/entities/dispute.entity.ts
@@ -1,0 +1,31 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, CreateDateColumn, Unique } from 'typeorm';
+import { OrderItem } from '../../orders/entities/order-item.entity';
+import { User } from '../../users/entities/user.entity';
+
+export enum DisputeStatus {
+  OPEN = 'OPEN',
+  RESOLVED = 'RESOLVED',
+  REJECTED = 'REJECTED',
+}
+
+@Entity('disputes')
+@Unique(['order_item'])
+export class Dispute {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ManyToOne(() => OrderItem, { nullable: false })
+  order_item: OrderItem;
+
+  @ManyToOne(() => User, { nullable: false })
+  buyer: User;
+
+  @Column({ type: 'enum', enum: DisputeStatus, default: DisputeStatus.OPEN })
+  status: DisputeStatus;
+
+  @Column({ type: 'text', nullable: true })
+  reason: string;
+
+  @CreateDateColumn()
+  created_at: Date;
+}

--- a/src/modules/disputes/services/dispute.service.ts
+++ b/src/modules/disputes/services/dispute.service.ts
@@ -1,0 +1,42 @@
+
+import { Injectable, BadRequestException, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Dispute, DisputeStatus } from '../entities/dispute.entity';
+import { OrderItem, OrderItemStatus } from '../../orders/entities/order-item.entity';
+import { User } from '../../users/entities/user.entity';
+
+@Injectable()
+export class DisputeService {
+  constructor(
+    @InjectRepository(Dispute)
+    private disputeRepository: Repository<Dispute>,
+    @InjectRepository(OrderItem)
+    private orderItemRepository: Repository<OrderItem>,
+  ) {}
+
+  async startDispute(orderItemId: string, buyer: { id: string | number }, reason?: string): Promise<Dispute> {
+    const orderItem = await this.orderItemRepository.findOne({ where: { id: orderItemId } });
+    if (!orderItem) throw new BadRequestException('Order item not found');
+    if (orderItem.status !== OrderItemStatus.ACTIVE) throw new BadRequestException('Only active milestones can be disputed');
+
+    const existing = await this.disputeRepository.findOne({ where: { order_item: { id: orderItemId } } });
+    if (existing) throw new BadRequestException('A dispute already exists for this milestone');
+
+    // Buscar el usuario completo
+  const buyerId = typeof buyer.id === 'string' ? parseInt(buyer.id, 10) : buyer.id;
+  const buyerUser = await this.orderItemRepository.manager.getRepository(User).findOne({ where: { id: buyerId } });
+    if (!buyerUser) throw new NotFoundException('Buyer not found');
+
+    const dispute = this.disputeRepository.create({
+      order_item: orderItem,
+      buyer: buyerUser,
+      status: DisputeStatus.OPEN,
+      reason,
+    });
+    await this.disputeRepository.save(dispute);
+    orderItem.status = OrderItemStatus.DISPUTED;
+    await this.orderItemRepository.save(orderItem);
+    return dispute;
+  }
+}

--- a/src/modules/disputes/tests/dispute.service.spec.ts
+++ b/src/modules/disputes/tests/dispute.service.spec.ts
@@ -1,0 +1,67 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DisputeService } from '../services/dispute.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Dispute, DisputeStatus } from '../entities/dispute.entity';
+import { OrderItem, OrderItemStatus } from '../../orders/entities/order-item.entity';
+import { User } from '../../users/entities/user.entity';
+
+const mockOrderItemRepo = () => ({
+  findOne: jest.fn(),
+  save: jest.fn(),
+  manager: {
+    getRepository: jest.fn().mockReturnValue({ findOne: jest.fn() }),
+  },
+});
+const mockDisputeRepo = () => ({
+  findOne: jest.fn(),
+  create: jest.fn(),
+  save: jest.fn(),
+});
+
+describe('DisputeService', () => {
+  let service: DisputeService;
+  let disputeRepo;
+  let orderItemRepo;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DisputeService,
+        { provide: getRepositoryToken(Dispute), useFactory: mockDisputeRepo },
+        { provide: getRepositoryToken(OrderItem), useFactory: mockOrderItemRepo },
+      ],
+    }).compile();
+    service = module.get<DisputeService>(DisputeService);
+    disputeRepo = module.get(getRepositoryToken(Dispute));
+    orderItemRepo = module.get(getRepositoryToken(OrderItem));
+  });
+
+  it('debe crear una disputa y actualizar el estado', async () => {
+    const orderItem = { id: 'oi1', status: OrderItemStatus.ACTIVE };
+    const user = { id: 1 };
+    orderItemRepo.findOne.mockResolvedValue(orderItem);
+    disputeRepo.findOne.mockResolvedValue(undefined);
+    orderItemRepo.manager.getRepository().findOne.mockResolvedValue(user);
+    disputeRepo.create.mockReturnValue({ id: 'd1', order_item: orderItem, buyer: user, status: DisputeStatus.OPEN });
+    disputeRepo.save.mockResolvedValue({ id: 'd1' });
+    orderItemRepo.save.mockResolvedValue({ ...orderItem, status: OrderItemStatus.DISPUTED });
+
+    const result = await service.startDispute('oi1', { id: 1 }, 'Motivo');
+    expect(result).toHaveProperty('id', 'd1');
+    expect(orderItemRepo.save).toHaveBeenCalledWith({ ...orderItem, status: OrderItemStatus.DISPUTED });
+  });
+
+  it('debe bloquear disputa duplicada', async () => {
+    const orderItem = { id: 'oi1', status: OrderItemStatus.ACTIVE };
+    orderItemRepo.findOne.mockResolvedValue(orderItem);
+    disputeRepo.findOne.mockResolvedValue({ id: 'd1' });
+    await expect(service.startDispute('oi1', { id: 1 }, 'Motivo')).rejects.toThrow('A dispute already exists for this milestone');
+  });
+
+  it('debe bloquear si el milestone no está activo', async () => {
+    const orderItem = { id: 'oi1', status: OrderItemStatus.DISPUTED };
+    orderItemRepo.findOne.mockResolvedValue(orderItem);
+    disputeRepo.findOne.mockResolvedValue(undefined);
+    await expect(service.startDispute('oi1', { id: 1 }, 'Motivo')).rejects.toThrow('Only active milestones can be disputed');
+  });
+});

--- a/src/modules/orders/entities/1695840100000-AddMilestoneAndStatusToOrderItem.ts
+++ b/src/modules/orders/entities/1695840100000-AddMilestoneAndStatusToOrderItem.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddMilestoneAndStatusToOrderItem1695840100000 implements MigrationInterface {
+    name = 'AddMilestoneAndStatusToOrderItem1695840100000'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "order_items" ADD COLUMN "milestone" varchar(255)`);
+        await queryRunner.query(`CREATE TYPE "order_item_status_enum" AS ENUM('ACTIVE', 'DISPUTED', 'COMPLETED')`);
+        await queryRunner.query(`ALTER TABLE "order_items" ADD COLUMN "status" "order_item_status_enum" NOT NULL DEFAULT 'ACTIVE'`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "order_items" DROP COLUMN "status"`);
+        await queryRunner.query(`DROP TYPE "order_item_status_enum"`);
+        await queryRunner.query(`ALTER TABLE "order_items" DROP COLUMN "milestone"`);
+    }
+}

--- a/src/modules/orders/entities/order-item.entity.ts
+++ b/src/modules/orders/entities/order-item.entity.ts
@@ -2,6 +2,12 @@ import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn } from 't
 import { Order } from './order.entity';
 import { Product } from '../../products/entities/product.entity';
 
+export enum OrderItemStatus {
+  ACTIVE = 'ACTIVE',
+  DISPUTED = 'DISPUTED',
+  COMPLETED = 'COMPLETED',
+}
+
 @Entity('order_items')
 export class OrderItem {
   @PrimaryGeneratedColumn('uuid')
@@ -18,6 +24,13 @@ export class OrderItem {
 
   @Column({ type: 'decimal', precision: 10, scale: 2 })
   price: number;
+
+
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  milestone: string | null;
+
+  @Column({ type: 'enum', enum: OrderItemStatus, default: OrderItemStatus.ACTIVE })
+  status: OrderItemStatus;
 
   @ManyToOne(() => Order, (order) => order.order_items)
   @JoinColumn({ name: 'order_id' })


### PR DESCRIPTION
# 🚀 StarShop Pull Request

Mark with an `x` all the checkboxes that apply (like `[x]`)

- [ ] Closes #
- [ ] Added tests (if necessary)
- [ ] Run tests
- [ ] Run formatting
- [ ] Evidence attached
- [ ] Commented the code

---

### 📌 Type of Change

- [ ] Documentation (updates to README, docs, or comments)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

---

## 📝 Changes description



---

## 📸 Evidence (A photo is required as evidence)



---

## ⏰ Time spent breakdown



---

## 🌌 Comments



---

Thank you for contributing to StarShop, we are glad that you have chosen us as your project of choice and we hope that you continue to contribute to this great project, so that together we can make our mark at the top!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added dispute management: authenticated users can open disputes for order items with a reason. Order items now track status (ACTIVE, DISPUTED, COMPLETED) and an optional milestone, and automatically update to DISPUTED when a dispute is opened.
- Tests
  - Introduced unit tests for dispute creation, duplicate prevention, and inactive-item safeguards.
- Chores
  - Added Git hooks to enforce Git LFS availability and run related actions after checkout, commit, merge, and before push.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->